### PR TITLE
Fix typo in polkit policy

### DIFF
--- a/com.endlessm.Coding.policy.in
+++ b/com.endlessm.Coding.policy.in
@@ -13,7 +13,7 @@
       <allow_inactive>yes</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">%pkglibexecdir%/coding-copy-files.js</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">%pkglibexecdir%/coding-copy-files</annotate>
   </action>
 
 </policyconfig>


### PR DESCRIPTION
This will bring back the polkit policy to run the
coding-copy-files without an extra authentication.