### PR TITLE
timeline: delay intro notification

### DIFF
--- a/data/timeline.json.unvalidated.in
+++ b/data/timeline.json.unvalidated.in
@@ -8,8 +8,7 @@
             "start_events": [
                 "chat::change::where_to_go",
                 "chat::change::where_to_go::input",
-                "chat::meme::intro::hook",
-                "chat::meme::intro::hook::challenge"
+                "chat::meme::intro::wait-intro"
             ],
             "artifacts": [
                 {
@@ -292,6 +291,17 @@
             "type": "start-mission",
             "data": {
                 "name": "intro"
+            }
+        },
+        {
+            "name": "chat::meme::intro::wait-intro",
+            "type": "wait-for",
+            "data": {
+                "timeout": 100000,
+                "then": [
+                    "chat::meme::intro::hook",
+                    "chat::meme::intro::hook::challenge"
+                ]
             }
         },
         {


### PR DESCRIPTION
This delays the intro notification so the user does not miss the message from MEME at startup.
https://phabricator.endlessm.com/T14481

Thought maybe that 5 minutes was a bit too long, but I can change it to that.

@smspillaz @cosimoc @ltilve can you have a look, thanks!