### PR TITLE
controller: Refactor out getStateForMissionName into separate func (T14746) 

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -121,6 +121,88 @@ function resolvePath(path, effects) {
     return parsedPath;
 }
 
+// getStateForMissionName
+//
+// Using the descriptors and game service log file, determine the current
+// state for the selected mission and return it as an object with
+// properties 'descriptor' and 'gameManagerState'
+//
+// This function will throw an error if the mission cannot be found.
+//
+// @param {array.Object} descriptors - An array of event descriptors parsed from
+//                                     the timeline.json file.
+// @param {Log.CodingGameServiceLog} eventLog - An eventLog object containing
+//                                              all the currently run events.
+// @returns {object} - The state for the current mission.
+function getStateForMissionName(name, descriptors, eventLog) {
+    // When a mission is started, we look at the very first event in this mission
+    // and dispatch that. We also set the active mission name and the points counter
+    let missionSpec = null, missionIndex = 0;
+
+    for (; missionIndex < descriptors.missions.length; ++missionIndex) {
+        if (descriptors.missions[missionIndex].name === name) {
+            missionSpec = descriptors.missions[missionIndex];
+            break;
+        }
+    }
+
+    if (!missionSpec)
+        throw new Error('No such mission named ' + name);
+
+    let totalAvailablePoints = missionSpec.artifacts.map(function(a) {
+        return a.points;
+    }).reduce(function(total, p) {
+        return total + p;
+    }, 0);
+
+    let completedEventsForMission = eventLog.artifactEventsWithNames(missionSpec.artifacts.map(function(a) {
+        return a.name;
+    }));
+
+    let totalAccruedPoints = Object.keys(completedEventsForMission).filter(function(k) {
+        return completedEventsForMission[k] !== null;
+    }).map(function(k) {
+        return findInArray(missionSpec.artifacts, function(a) {
+            return a.name === k;
+        });
+    }).reduce(function(total, a) {
+        return total + a.points;
+    }, 0);
+
+    let earnedArtifacts = eventLog.allUniqueArtifactEvents().map(Lang.bind(this, function(a) {
+        for (let mission of descriptors.missions) {
+            for (let missionArtifact of mission.artifacts) {
+                if (missionArtifact.name === a.data.name)
+                    return missionArtifact;
+            }
+        }
+
+        throw new Error('Couldn\'t find corresponding artifact description for: ' +
+                        a.data.name);
+    }));
+
+    return {
+        descriptor: missionSpec,
+        gameManagerState: {
+            currentMission: missionSpec.name,
+            currentMissionStageNum: missionIndex + 1,
+            currentMissionName: missionSpec.short_desc,
+            currentMissionDesc: missionSpec.long_desc,
+            // In the future we will probably want this to be a per-artifact level,
+            // though the current non-linear architecture does not fit well with
+            // that (what is the 'next' artifact when there could be many?).
+            currentMissionHint: missionSpec.hint,
+            currentMissionNumTasksAvailable: Object.keys(completedEventsForMission).length,
+            currentMissionNumTasks: Object.keys(completedEventsForMission).filter(function(k) {
+                return completedEventsForMission[k] !== null;
+            }).length,
+            currentMissionPoints: totalAccruedPoints,
+            currentMissionPointsAvailable: totalAvailablePoints,
+            earnedArtifacts: earnedArtifacts
+        }
+    };
+}
+
 const CodingGameController = new Lang.Class({
     Name: 'CodingGameController',
 
@@ -204,9 +286,13 @@ const CodingGameController = new Lang.Class({
         // If we started for the first time, dispatch the very first mission
         let activeMission = this._log.activeMission();
 
-        if (activeMission)
-            this._startMission(activeMission);
-        else {
+        if (activeMission) {
+            // Don't start the active mission. Instead, get the state of the
+            // game manager for this mission and set that.
+            let missionSpec = getStateForMissionName(activeMission, this._descriptors, this._log);
+            this._service.setGameManagerState(missionSpec.gameManagerState);
+        } else {
+            // No active mission. Fire the very first event
             this._startFirstMission();
         }
     },
@@ -429,71 +515,10 @@ const CodingGameController = new Lang.Class({
     },
 
     _startMission: function(name) {
-        // When a mission is started, we look at the very first event in this mission
-        // and dispatch that. We also set the active mission name and the points counter
-        let missionSpec = null, missionIndex = 0;
+        let missionSpec = getStateForMissionName(name, this._descriptors, this._log);
 
-        for (; missionIndex < this._descriptors.missions.length; ++missionIndex) {
-            if (this._descriptors.missions[missionIndex].name === name) {
-                missionSpec = this._descriptors.missions[missionIndex];
-                break;
-            }
-        }
-
-        if (!missionSpec)
-            throw new Error('No such mission named ' + name);
-
-        let totalAvailablePoints = missionSpec.artifacts.map(function(a) {
-            return a.points;
-        }).reduce(function(total, p) {
-            return total + p;
-        }, 0);
-
-        let completedEventsForMission = this._log.artifactEventsWithNames(missionSpec.artifacts.map(function(a) {
-            return a.name;
-        }));
-
-        let totalAccruedPoints = Object.keys(completedEventsForMission).filter(function(k) {
-            return completedEventsForMission[k] !== null;
-        }).map(function(k) {
-            return findInArray(missionSpec.artifacts, function(a) {
-                return a.name === k;
-            });
-        }).reduce(function(total, a) {
-            return total + a.points;
-        }, 0);
-
-        let earnedArtifacts = this._log.allUniqueArtifactEvents().map(Lang.bind(this, function(a) {
-            for (let mission of this._descriptors.missions) {
-                for (let missionArtifact of mission.artifacts) {
-                    if (missionArtifact.name === a.data.name)
-                        return missionArtifact;
-                }
-            }
-
-            throw new Error('Couldn\'t find corresponding artifact description for: ' +
-                            a.data.name);
-        }));
-
-        this._service.setGameManagerState({
-            currentMission: missionSpec.name,
-            currentMissionStageNum: missionIndex + 1,
-            currentMissionName: missionSpec.short_desc,
-            currentMissionDesc: missionSpec.long_desc,
-            // In the future we will probably want this to be a per-artifact level,
-            // though the current non-linear architecture does not fit well with
-            // that (what is the 'next' artifact when there could be many?).
-            currentMissionHint: missionSpec.hint,
-            currentMissionNumTasksAvailable: Object.keys(completedEventsForMission).length,
-            currentMissionNumTasks: Object.keys(completedEventsForMission).filter(function(k) {
-                return completedEventsForMission[k] !== null;
-            }).length,
-            currentMissionPoints: totalAccruedPoints,
-            currentMissionPointsAvailable: totalAvailablePoints,
-            earnedArtifacts: earnedArtifacts
-        });
-
-        missionSpec.start_events.forEach(Lang.bind(this, function(start_event) {
+        this._service.setGameManagerState(missionSpec.gameManagerState);
+        missionSpec.descriptor.start_events.forEach(Lang.bind(this, function(start_event) {
             let event = findInArray(this._descriptors.events, function(e) {
                 return e.name === start_event;
             });


### PR DESCRIPTION
Previously we were calling _startMission unconditionally every time
the chatbox started up. The previous assumption was that calling
_startMission on an already-started mission was a no-opt, but that
was invalidated when we added the CHANGE actor since there was a need
to return to already-completed or started missions there. That was
causing duplicate messages to appear every time the game service
was killed and restarted (since it would always try and restart
the currently active mission).

https://phabricator.endlessm.com/T14746