### PR TITLE
service: Manually unpack values in inventory variants

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -193,7 +193,15 @@ const DBUSService = new Lang.Class({
         this.current_mission_points += artifact.points;
         this.current_mission_num_tasks++;
         this.earned_artifacts = earnedArtifactsVariantForArrayOfObjects(
-            this.earned_artifacts.deep_unpack().concat([
+            this.earned_artifacts.deep_unpack().map(function(obj) {
+                // We need to manually deserialize the rest of the variant
+                // here by doing what coding-game-manager does
+                let ret = {};
+                Object.keys(obj).map(function(key) {
+                    ret[key] = obj[key].get_string()[0];
+                })
+                return ret;
+            }).concat([
                 artifactForStage(artifact, this.current_mission_stage_num)
             ])
         );


### PR DESCRIPTION
deep_unpack() only goes as far as unpacking the variant array
but it does not unpack the values of the keys. Do what
coding-game-manager does and also unpack those values before
appending to the variant and re-serializing.

https://phabricator.endlessm.com/T14921