### PR TITLE
Don't require opening images to advance on processing and codeview lessons

### DIFF
--- a/data/timeline.json.unvalidated.in
+++ b/data/timeline.json.unvalidated.in
@@ -964,16 +964,28 @@
         },
         {
             "name": "chat::ada::processing::show_processing_interface_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::processing::chat_first_code",
                         "chat::ada::processing::code_print_console",
                         "chat::ada::processing::chat_explain_comments",
                         "chat::ada::processing::chat_check_print",
                         "chat::ada::processing::chat_check_print::response"
-                ]
+                    ]
+                }
             }
         },
         {
@@ -1098,13 +1110,25 @@
         },
         {
             "name": "chat::ada::processing::show_line_example_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::processing::chat_check_line",
                         "chat::ada::processing::chat_check_line::response"
-                ]
+                    ]
+                }
             }
         },
         {
@@ -1286,13 +1310,25 @@
         },
         {
             "name": "chat::ada::processing::show_circle_example_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::processing::chat_check_circle",
                         "chat::ada::processing::chat_check_circle::response"
-                ]
+                    ]
+                }
             }
         },
         {
@@ -1454,13 +1490,25 @@
         },
         {
             "name": "chat::ada::processing::show_martian_example_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::processing::chat_check_martian_appeared",
                         "chat::ada::processing::chat_check_martian_appeared::response"
-                ]
+                    ]
+                }
             }
         },
         {
@@ -1621,12 +1669,25 @@
         },
         {
             "name": "chat::ada::processing::show_martian_colors_example_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::processing::chat_check_martian_colors",
-                        "chat::ada::processing::chat_check_martian_colors::response"                ]
+                        "chat::ada::processing::chat_check_martian_colors::response"
+                    ]
+                }
             }
         },
         {
@@ -1953,13 +2014,25 @@
         },
         {
             "name": "chat::ada::codeview::weather::flip_screen::hint_screenshot_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::codeview::weather::flip_screen::hint_chat_second",
                         "chat::ada::codeview::weather::flip_screen::response"
-                ]
+                    ]
+                }
             }
         },
         {
@@ -2024,17 +2097,29 @@
         },
         {
             "name": "chat::ada::codeview::weather::editor::overview::screenshot_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::codeview::weather::editor::task",
                         "chat::ada::codeview::weather::first_task::description",
                         "chat::ada::codeview::weather::first_task::overview",
                         "chat::ada::codeview::weather::first_task::navigate",
                         "chat::ada::codeview::weather::first_task::select",
                         "chat::ada::codeview::weather::first_task::pause"
-                ]
+                    ]
+                }
             }
         },
         {
@@ -2159,13 +2244,25 @@
         },
         {
             "name": "chat::ada::codeview::weather::first_task::challenge::screenshot_pause",
-            "type": "wait-for",
+            "type": "input-user",
             "data": {
-                "timeout": 10000,
-                "then": [
+                "actor": "Ada",
+                "input": {
+                    "type": "choice",
+                    "settings": {
+                        "choices": {
+                            "yes": {
+                                "text": "Ready!"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "yes": [
                         "chat::ada::codeview::weather::first_task::challenge::prompt",
                         "chat::ada::codeview::weather::first_task::challenge"
-                ]
+                    ]
+                }
             }
         },
         {


### PR DESCRIPTION
As it is not explicit to the user that he needed to click on the images to advance on the lessons, use a 5 seconds timeout instead.

https://phabricator.endlessm.com/T14814