### PR TITLE
remove processing copy event from timeline

### DIFF
--- a/data/timeline.json.unvalidated.in
+++ b/data/timeline.json.unvalidated.in
@@ -134,7 +134,6 @@
                 "chat::ada::processing::time_something_new",
                 "chat::ada::processing::processing_tool_drawings",
                 "chat::ada::processing::chat_beginner_tutorial",
-                "event::ada::processing::copy_processing_desktop_file",
                 "event::ada::processing::insert_processing_icon",
                 "chat::ada::processing::show_icon",
                 "chat::ada::processing::show_icon_pause"
@@ -952,14 +951,6 @@
             "actor": "Ada",
             "message": "To get started, click the Processing icon on the desktop. It should look like this:"
           }
-        },
-        {
-            "name": "event::ada::processing::copy_processing_desktop_file",
-            "type": "copy-file",
-            "data": {
-                "source": "org.processing.App.desktop",
-                "target": "~/.local/share/applications/org.processing.App.desktop"
-            }
         },
         {
             "name": "event::ada::processing::insert_processing_icon",


### PR DESCRIPTION
Processing application is by default on the image, so we do not need to
add or subsequently remove it.

https://phabricator.endlessm.com/T15086

cc @smspillaz  @erikos 