### PR TITLE
shim: Remove coding_game_service_app_integration_controller_new

### DIFF
--- a/lib/shim.c
+++ b/lib/shim.c
@@ -216,6 +216,11 @@ coding_game_service_app_integration_controller_init(CodingGameServiceAppIntegrat
   }
 }
 
+CodingGameServiceAppIntegrationController *
+coding_game_service_app_integration_controller_new () {
+  return g_object_new(CODING_GAME_SERVICE_TYPE_APP_INTEGRATION_CONTROLLER);
+}
+
 static void
 coding_game_service_app_integration_controller_class_init(CodingGameServiceAppIntegrationControllerClass *klass)
 {

--- a/lib/shim.c
+++ b/lib/shim.c
@@ -217,7 +217,7 @@ coding_game_service_app_integration_controller_init(CodingGameServiceAppIntegrat
 }
 
 CodingGameServiceAppIntegrationController *
-coding_game_service_app_integration_controller_new () {
+coding_game_service_app_integration_controller_new (void) {
   return g_object_new(CODING_GAME_SERVICE_TYPE_APP_INTEGRATION_CONTROLLER, NULL);
 }
 

--- a/lib/shim.c
+++ b/lib/shim.c
@@ -218,7 +218,7 @@ coding_game_service_app_integration_controller_init(CodingGameServiceAppIntegrat
 
 CodingGameServiceAppIntegrationController *
 coding_game_service_app_integration_controller_new () {
-  return g_object_new(CODING_GAME_SERVICE_TYPE_APP_INTEGRATION_CONTROLLER);
+  return g_object_new(CODING_GAME_SERVICE_TYPE_APP_INTEGRATION_CONTROLLER, NULL);
 }
 
 static void

--- a/lib/shim.h
+++ b/lib/shim.h
@@ -22,7 +22,7 @@ G_DECLARE_FINAL_TYPE (CodingGameServiceAppIntegrationController,
                       APP_INTEGRATION_CONTROLLER,
                       GObject)
 
-CodingGameServiceAppIntegrationController *coding_game_service_app_integration_controller_new ();
+CodingGameServiceAppIntegrationController *coding_game_service_app_integration_controller_new (void);
 
 typedef void (*CodingGameServiceAppIntegrationControllerInterestCallback)(CodingGameServiceAppIntegrationController *controller, gpointer user_data);
 


### PR DESCRIPTION
It was never actually defined and from Gjs we use g_object_newv

https://phabricator.endlessm.com/T13630