### PR TITLE
timeline: Tweak CodeView timeline to support external events

### DIFF
--- a/data/timeline.json.unvalidated.in
+++ b/data/timeline.json.unvalidated.in
@@ -179,7 +179,7 @@
                 "chat::ada::codeview::weather::guessed",
                 "chat::ada::codeview::weather::changed",
                 "chat::ada::codeview::weather::start_app",
-                "chat::ada::codeview::weather::start_app::response"
+                "listen::codeview::weather::start_app"
             ],
             "artifacts": [
                 {
@@ -2043,34 +2043,21 @@
             "type": "chat-actor",
             "data": {
                 "actor": "Ada",
-                "message": "On the desktop, you should see an icon for the “Weather” app. Click the icon, and let me know once the app opens."
+                "message": "On the desktop, you should see an icon for the “Weather” app. Click that icon and come back here"
             }
         },
         {
-            "name": "chat::ada::codeview::weather::start_app::response",
-            "type": "input-user",
+            "name": "listen::codeview::weather::start_app",
+            "type": "listen-event",
             "data": {
-                "actor": "Ada",
-                "input": {
-                    "type": "choice",
-                    "settings": {
-                        "prompt": "Opened the app?",
-                        "choices": {
-                            "yes": {
-                                "text": "Done!"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "yes": [
-                        "chat::ada::codeview::weather::start_app::old",
-                        "chat::ada::codeview::weather::start_app::what",
-                        "chat::ada::codeview::weather::flip_screen::hint_chat",
-                        "chat::ada::codeview::weather::flip_screen::hint_screenshot",
-                        "chat::ada::codeview::weather::flip_screen::hint_screenshot_pause"
-                    ]
-                }
+                "name": "codeview-app-opened",
+                "received": [
+                    "chat::ada::codeview::weather::start_app::old",
+                    "chat::ada::codeview::weather::start_app::what",
+                    "chat::ada::codeview::weather::flip_screen::hint_chat",
+                    "chat::ada::codeview::weather::flip_screen::hint_screenshot",
+                    "chat::ada::codeview::weather::flip_screen::hint_screenshot_pause"
+                ]
             }
         },
         {
@@ -2127,7 +2114,7 @@
                 "responses": {
                     "yes": [
                         "chat::ada::codeview::weather::flip_screen::hint_chat_second",
-                        "chat::ada::codeview::weather::flip_screen::response"
+                        "listen::codeview::weather::flip_screen::response"
                     ]
                 }
             }
@@ -2141,29 +2128,15 @@
             }
         },
         {
-            "name": "chat::ada::codeview::weather::flip_screen::response",
-            "type": "input-user",
+            "name": "listen::codeview::weather::flip_screen::response",
+            "type": "listen-event",
             "data": {
-                "actor": "Ada",
-                "input": {
-                    "type": "choice",
-                    "settings": {
-                        "prompt": "Flipped the app?",
-                        "choices": {
-                            "yes": {
-                                "text": "Done!"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "yes": [
-                        "chat::ada::codeview::weather::editor::welcome",
-                        "chat::ada::codeview::weather::editor::overview",
-                        "chat::ada::codeview::weather::editor::overview::screenshot",
-                        "chat::ada::codeview::weather::editor::overview::screenshot_pause"
-                    ]
-                }
+                "name": "codeview-flipped",
+                "received": [
+                    "chat::ada::codeview::weather::editor::welcome",
+                    "chat::ada::codeview::weather::editor::wait_install",
+                    "listen::codeview::weather::editor::wait_install"
+                ]
             }
         },
         {
@@ -2172,6 +2145,26 @@
             "data": {
                 "actor": "Ada",
                 "message": "Welcome to CodeView."
+            }
+        },
+        {
+            "name": "chat::ada::codeview::weather::editor::wait_install",
+            "type": "chat-actor",
+            "data": {
+                "actor": "Ada",
+                "message": "Just waiting on the source code to download."
+            }
+        },
+        {
+            "name": "listen::codeview::weather::editor::wait_install",
+            "type": "listen-event",
+            "data": {
+                "name": "codeview-installed",
+                "received": [
+                    "chat::ada::codeview::weather::editor::overview",
+                    "chat::ada::codeview::weather::editor::overview::screenshot",
+                    "chat::ada::codeview::weather::editor::overview::screenshot_pause"
+                ]
             }
         },
         {


### PR DESCRIPTION
We now respond to codeview-started, codeview-flipped and
codeview-installed to drive some of the messages instead
of waiting on the user to press the "ready" button.

https://phabricator.endlessm.com/T13630