### PR TITLE
timeline: remove playsong from unlocked lessons

### DIFF
--- a/data/timeline.json.unvalidated.in
+++ b/data/timeline.json.unvalidated.in
@@ -706,7 +706,7 @@
                 "variant_type": "as",
                 "value": {
                     "type": "append-to-list-unique",
-                    "value": ["showmehow", "joke", "playsong", "readfile", "breakit", "navigation"]
+                    "value": ["showmehow", "joke", "readfile", "breakit", "navigation"]
                 }
             }
         },


### PR DESCRIPTION
Remove the playsong, as we don't want it by default in our lessons.

https://phabricator.endlessm.com/T16154