### PR TITLE
CodeView, coding-dev-reset: use the flatpakID for upstream GNOME Weather

### DIFF
--- a/bin/coding-dev-reset
+++ b/bin/coding-dev-reset
@@ -8,9 +8,9 @@ gsettings reset org.gnome.shell wobbly-effect
 killall -9 -q /usr/bin/gjs || true
 
 cd ~/Projects/gnome-weather && git reset --hard HEAD
-flatpak --user uninstall org.gnome.Weather.Application
-rm -rf ~/.cache/app/org.gnome.Weather.Application/
-rm -rf ~/.var/app/org.gnome.Weather.Application/
+flatpak --user uninstall org.gnome.Weather
+rm -rf ~/.cache/app/org.gnome.Weather/
+rm -rf ~/.var/app/org.gnome.Weather/
 
 rm -rf ~/.var/app/org.gnome.Builder/cache/gnome-builder/builds/gnome-weather
 rm -rf ~/.var/app/org.gnome.Builder/data/gnome-builder/drafts/gnome-weather


### PR DESCRIPTION
We want to pull in the upstream version instead of
our custom endless one. Part of T16393